### PR TITLE
Fix: NameError in label_serch.py

### DIFF
--- a/autoprompt/label_search.py
+++ b/autoprompt/label_search.py
@@ -28,10 +28,10 @@ def load_pretrained(model_name):
     Loads pretrained HuggingFace config/model/tokenizer, as well as performs required
     initialization steps to facilitate working with triggers.
     """
-    config = AutoConfig.from_pretrained(args.model_name)
-    model = AutoModelWithLMHead.from_pretrained(args.model_name, config=config)
+    config = AutoConfig.from_pretrained(model_name)
+    model = AutoModelWithLMHead.from_pretrained(model_name, config=config)
     model.eval()
-    tokenizer = AutoTokenizer.from_pretrained(args.model_name)
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
     utils.add_task_specific_tokens(tokenizer)
     return config, model, tokenizer
 


### PR DESCRIPTION
Fixed the below error in ` label_serch.py`

`args.model_name` was not suitable for `load_pretrained(model_name) `
So I convert  `args.model_name` to `model_name`, and it works


### more detail
-------------------
-- Process 0 terminated with the following error:
Traceback (most recent call last):
  File "/home/als398/.conda/envs/autoprompt/lib/python3.7/site-packages/torch/multiprocessing/spawn.py", line 19, in _wrap
    fn(i, *args)
  File "/home/als398/test/autoprompt/label_search.py", line 81, in main
    config, model, tokenizer = load_pretrained(args.model_name)
  File "/home/als398/test/autoprompt/label_search.py", line 34, in load_pretrained
    config = AutoConfig.from_pretrained(args.model_name)
NameError: name 'args' is not defined